### PR TITLE
Dispatch events immediately

### DIFF
--- a/src/Events/LargoSessionFailed.php
+++ b/src/Events/LargoSessionFailed.php
@@ -8,11 +8,11 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class LargoSessionFailed implements ShouldBroadcast
+class LargoSessionFailed implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Events/LargoSessionSaved.php
+++ b/src/Events/LargoSessionSaved.php
@@ -8,11 +8,11 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class LargoSessionSaved implements ShouldBroadcast
+class LargoSessionSaved implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
Resolves #105 by using shouldBroadcastNow

Class shouldBroadcast uses default queue which can lead to delayed event dispatching when the queue is busy.
Use shouldBroadcastNow to dispatch events immediately.