### PR TITLE
Add indices to feature vector tables

### DIFF
--- a/src/Database/migrations/2023_12_15_153400_create_annotation_feature_vectors_tables.php
+++ b/src/Database/migrations/2023_12_15_153400_create_annotation_feature_vectors_tables.php
@@ -69,7 +69,7 @@ return new class extends Migration
                 // For Largo queries.
                 $table->index(['label_id', 'volume_id']);
 
-                // For create/update queries.
+                // For create/update/delete(cascade) queries.
                 $table->index('annotation_id');
 
                 // Ensure consistency and speed up updateOrCreate queries.
@@ -107,7 +107,7 @@ return new class extends Migration
                 // For Largo queries.
                 $table->index(['label_id', 'volume_id']);
 
-                // For create/update queries.
+                // For create/update/delete(cascade) queries.
                 $table->index('annotation_id');
 
                 // Ensure consistency and speed up updateOrCreate queries.

--- a/src/Database/migrations/2024_01_31_110300_add_annotation_feature_vectors_indices.php
+++ b/src/Database/migrations/2024_01_31_110300_add_annotation_feature_vectors_indices.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        /*
+         * Explanation: These indices are crutial for the foreign key constraints.
+         * For example, if a label or a label tree should be deleted, the DB must check
+         * if there are any feature vectors using the label/tree. Without index this
+         * is terribly slow on large tables (and these tables will be large here).
+         * The same is true for cascaded deletes. If a whole image/video or volume should
+         * be deleted, the feature vectors are deleted via their foreign key constraints.
+         * The index is essential for this to be fast. Otherwise a query could take hours
+         * or days!
+         */
+        Schema::table('image_annotation_label_feature_vectors', function (Blueprint $table) {
+            $table->index('id');
+            $table->index('label_id');
+            $table->index('label_tree_id');
+
+            // This is not needed. If a volume is deleted, deletion of the vectors is
+            // cascaded through the annotations.
+            $table->dropForeign(['volume_id']);
+        });
+
+        Schema::table('video_annotation_label_feature_vectors', function (Blueprint $table) {
+            $table->index('id');
+            $table->index('label_id');
+            $table->index('label_tree_id');
+
+            // This is not needed. If a volume is deleted, deletion of the vectors is
+            // cascaded through the annotations.
+            $table->dropForeign(['volume_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('image_annotation_label_feature_vectors', function (Blueprint $table) {
+            $table->foreignId('volume_id')
+                ->constrained()
+                ->onDelete('cascade');
+        });
+
+        Schema::table('video_annotation_label_feature_vectors', function (Blueprint $table) {
+            $table->foreignId('volume_id')
+                ->constrained()
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/tests/ImageAnnotationLabelFeatureVectorTest.php
+++ b/tests/ImageAnnotationLabelFeatureVectorTest.php
@@ -54,8 +54,11 @@ class ImageAnnotationLabelFeatureVectorTest extends TestCase
 
     public function testDeleteVolumeCascade()
     {
-        $v = ImageAnnotationLabelFeatureVector::factory()->create();
-        Volume::where('id', $v->volume_id)->delete();
+        $a = ImageAnnotation::factory()->create();
+        $v = ImageAnnotationLabelFeatureVector::factory()->create([
+            'annotation_id' => $a->id,
+        ]);
+        $a->image->volume->delete();
         $this->assertNull($v->fresh());
     }
 }

--- a/tests/VideoAnnotationLabelFeatureVectorTest.php
+++ b/tests/VideoAnnotationLabelFeatureVectorTest.php
@@ -54,8 +54,11 @@ class VideoAnnotationLabelFeatureVectorTest extends TestCase
 
     public function testDeleteVolumeCascade()
     {
-        $v = VideoAnnotationLabelFeatureVector::factory()->create();
-        Volume::where('id', $v->volume_id)->delete();
+        $a = VideoAnnotation::factory()->create();
+        $v = VideoAnnotationLabelFeatureVector::factory()->create([
+            'annotation_id' => $a->id,
+        ]);
+        $a->video->volume->delete();
         $this->assertNull($v->fresh());
     }
 }


### PR DESCRIPTION
The indices are crucial for the efficient processing of foreign key constraints.

See also: https://github.com/biigle/maia/pull/157