### PR TITLE
Fix division by error

### DIFF
--- a/src/Jobs/ProcessAnnotatedFile.php
+++ b/src/Jobs/ProcessAnnotatedFile.php
@@ -420,7 +420,7 @@ abstract class ProcessAnnotatedFile extends GenerateFeatureVectors
     protected function computeRotationAngle(array $v, array $u): float
     {
         // If (upper) left and (upper) right coordinate have equal y coordinate, then there is no rotation
-        if ($v[1] == 0) {
+        if (intval($v[1]) === 0) {
             return 0;
         }
 
@@ -428,7 +428,7 @@ abstract class ProcessAnnotatedFile extends GenerateFeatureVectors
         $scalarProd = 0;
         $vNorm = 0;
         $uNorm = 0;
-        for ($i = 0; $i < sizeof($v); $i++) {
+        for ($i = 0; $i < count($v); $i++) {
             $scalarProd += $v[$i] * $u[$i];
             $vNorm += pow($v[$i], 2);
             $uNorm += pow($u[$i], 2);

--- a/src/Jobs/ProcessAnnotatedFile.php
+++ b/src/Jobs/ProcessAnnotatedFile.php
@@ -410,7 +410,7 @@ abstract class ProcessAnnotatedFile extends GenerateFeatureVectors
     protected function computeRotationAngle(array $v, array $u): float
     {
         // If (upper) left and (upper) right coordinate have equal y coordinate, then there is no rotation
-        if ($v[1] === 0) {
+        if ($v[1] == 0) {
             return 0;
         }
 

--- a/tests/Jobs/ProcessAnnotatedImageTest.php
+++ b/tests/Jobs/ProcessAnnotatedImageTest.php
@@ -649,8 +649,10 @@ class ProcessAnnotatedImageTest extends TestCase
         $disk = Storage::fake('test');
         $image = $this->getImageMock();
         $annotation = ImageAnnotationTest::create([
-            'points' => [0, 0, 0, 0, 0, 0, 0, 0], // ellipse must not be a point
-            'shape_id' => Shape::ellipseId(),
+            // This is a real-world example where someone managed to create a zero-sized
+            // rectangle.
+            'points' => [844.69,1028.44,844.69,1028.44,844.69,1028.44,844.69,1028.44],
+            'shape_id' => Shape::rectangleId(),
         ]);
         $job = new ProcessAnnotatedImageStub($annotation->image);
         $job->mock = $image;

--- a/tests/Jobs/ProcessAnnotatedImageTest.php
+++ b/tests/Jobs/ProcessAnnotatedImageTest.php
@@ -642,6 +642,28 @@ class ProcessAnnotatedImageTest extends TestCase
         $this->assertEquals(1, ImageAnnotationLabelFeatureVector::count());
     }
 
+    public function testHandleInvalidShape()
+    {
+        config(['thumbnails.height' => 100, 'thumbnails.width' => 100]);
+        $disk = Storage::fake('test');
+        $image = $this->getImageMock();
+        $annotation = ImageAnnotationTest::create([
+            'points' => [0, 0, 0, 0, 0, 0, 0, 0], // ellipse must not be a point
+            'shape_id' => Shape::ellipseId(),
+        ]);
+        $job = new ProcessAnnotatedImageStub($annotation->image);
+        $job->mock = $image;
+
+        $image->shouldReceive('crop')
+            ->once()
+            ->andReturn($image);
+
+        $image->shouldReceive('writeToBuffer')->once()->andReturn('abc123');
+
+        // Assert that no exception is thrown
+        $job->handle();
+    }
+
     protected function getImageMock($times = 1)
     {
         $image = Mockery::mock();

--- a/tests/Jobs/ProcessAnnotatedVideoTest.php
+++ b/tests/Jobs/ProcessAnnotatedVideoTest.php
@@ -735,9 +735,11 @@ class ProcessAnnotatedVideoTest extends TestCase
         $disk = Storage::fake('test2');
         $video = $this->getFrameMock();
         $annotation = VideoAnnotationTest::create([
-            'points' => [[0, 0, 0, 0, 0, 0, 0, 0]], // Ellipse must not be a point
+            // This is a real-world example where someone managed to create a zero-sized
+            // rectangle.
+            'points' => [[844.69,1028.44,844.69,1028.44,844.69,1028.44,844.69,1028.44]],
             'frames' => [0],
-            'shape_id' => Shape::ellipseId(),
+            'shape_id' => Shape::rectangleId(),
         ]);
         $job = new ProcessAnnotatedVideoStub($annotation->video, targetDisk: 'test2');
         $job->mock = $video;


### PR DESCRIPTION
Fix error by comparing values instead of values and type.