### PR TITLE
Change failure behavior of ProcessAnnotatedFile job

### DIFF
--- a/src/Exceptions/ProcessAnnotatedFileException.php
+++ b/src/Exceptions/ProcessAnnotatedFileException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Biigle\Modules\Largo\Exceptions;
+
+class ProcessAnnotatedFileException extends \Exception
+{
+    //
+}


### PR DESCRIPTION
The job now throws an exception when it gives up retrying so it fill properly logged as a failed job. Also it will now retry even if the exception is unknown. If the exception is known, it will retry even more often.