### PR TITLE
Improve error handling of ProcessAnnotatedFile job

### DIFF
--- a/tests/Jobs/ProcessAnnotatedImageTest.php
+++ b/tests/Jobs/ProcessAnnotatedImageTest.php
@@ -394,6 +394,7 @@ class ProcessAnnotatedImageTest extends TestCase
 
         $annotation = ImageAnnotationTest::create();
         $job = new ProcessAnnotatedImage($annotation->image);
+        $job->tries = 1;
         $job->handle();
         $prefix = fragment_uuid_path($annotation->image->uuid);
         $disk->assertMissing("{$prefix}/{$annotation->id}.svg");

--- a/tests/Jobs/ProcessAnnotatedVideoTest.php
+++ b/tests/Jobs/ProcessAnnotatedVideoTest.php
@@ -437,6 +437,7 @@ class ProcessAnnotatedVideoTest extends TestCase
 
         $annotation = VideoAnnotationTest::create();
         $job = new ProcessAnnotatedVideo($annotation->video);
+        $job->tries = 1;
         $job->handle();
         $prefix = fragment_uuid_path($annotation->video->uuid);
         $disk->assertMissing("{$prefix}/v-{$annotation->id}.svg");


### PR DESCRIPTION
The job is now retried even if an error happens that would make it give up. If the error persists, the job does not fail and just writes a log message.