### PR TITLE
Specfiy branch name for torch.hub model

### DIFF
--- a/src/resources/scripts/ExtractFeatures.py
+++ b/src/resources/scripts/ExtractFeatures.py
@@ -19,7 +19,7 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 with open(sys.argv[1], 'r') as f:
     input_json = json.load(f)
 
-dinov2_vits14 = hub_load('facebookresearch/dinov2', 'dinov2_vits14')
+dinov2_vits14 = hub_load('facebookresearch/dinov2:main', 'dinov2_vits14')
 
 if cuda_is_available():
     device = device('cuda')


### PR DESCRIPTION
If the branch name is omitted, torch.hub tries to guess the branch by sending a HTTP request to GitHub, even if the model is cached locally. This can run into the GitHub API rate limit.