### PR TITLE
Chunking  in StoreLargoSession

### DIFF
--- a/src/Http/Requests/StoreLargoSession.php
+++ b/src/Http/Requests/StoreLargoSession.php
@@ -112,7 +112,7 @@ class StoreLargoSession extends FormRequest
      */
     protected function imageAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $chunkedI = array_chunk($annotations,65000);
+        $chunkedI = array_chunk($annotations,config('biigle.db_param_limit')-1); 
         foreach($chunkedI as $ci){
             $queryReturnI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
                 ->whereIn('image_annotations.id', $ci)
@@ -136,7 +136,7 @@ class StoreLargoSession extends FormRequest
      */
     protected function videoAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $chunkedV = array_chunk($annotations,65000);
+        $chunkedV = array_chunk($annotations,config('biigle.db_param_limit')-1); // config('biigle.db_param_limit')
         foreach($chunkedV as $cv){
             $queryReturnV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
                 ->whereIn('video_annotations.id', $cv)

--- a/src/Http/Requests/StoreLargoSession.php
+++ b/src/Http/Requests/StoreLargoSession.php
@@ -112,7 +112,6 @@ class StoreLargoSession extends FormRequest
      */
     protected function imageAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $leni = count($annotations);
         $chunkedI = array_chunk($annotations,65000);
         foreach($chunkedI as $ci){
             $queryReturnI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
@@ -137,7 +136,6 @@ class StoreLargoSession extends FormRequest
      */
     protected function videoAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $lenv = count($annotations);
         $chunkedV = array_chunk($annotations,65000);
         foreach($chunkedV as $cv){
             $queryReturnV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')

--- a/src/Http/Requests/StoreLargoSession.php
+++ b/src/Http/Requests/StoreLargoSession.php
@@ -113,22 +113,18 @@ class StoreLargoSession extends FormRequest
     protected function imageAnotationsBelongToVolumes($annotations, $volumes)
     {
         $leni = count($annotations);
-        if ($leni<65000){
-            return !ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                ->whereIn('image_annotations.id', $annotations)
+        $chunkedI = array_chunk($annotations,65000);
+        foreach($chunkedI as $ci){
+            $queryReturnI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $ci)
                 ->whereNotIn('images.volume_id', $volumes)
                 ->exists();
-        }
-        else {
-            $chunkedI = array_chunk($annotations,65000);
-            foreach($chunkedI as $ci){
-                return !ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                    ->whereIn('image_annotations.id', $ci)
-                    ->whereNotIn('images.volume_id', $volumes)
-                    ->exists();
+            if ($queryReturnI){
+                return false;
             }
         }
-
+        return true;
+        
     }
 
     /**
@@ -142,21 +138,17 @@ class StoreLargoSession extends FormRequest
     protected function videoAnotationsBelongToVolumes($annotations, $volumes)
     {
         $lenv = count($annotations);
-        if ($lenv<65000){
-            return !VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-                ->whereIn('video_annotations.id', $annotations)
-                ->whereNotIn('videos.volume_id', $volumes)
-                ->exists();
-        }
-        else {
-            $chunkedV = array_chunk($annotations,65000);
-            foreach($chunkedV as $cv){
-                return !VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+        $chunkedV = array_chunk($annotations,65000);
+        foreach($chunkedV as $cv){
+            $queryReturnV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
                 ->whereIn('video_annotations.id', $cv)
                 ->whereNotIn('videos.volume_id', $volumes)
                 ->exists();
+            if ($queryReturnV){
+                return false;
             }
         }
+        return true;
     }
 
     /**

--- a/src/Http/Requests/StoreLargoSession.php
+++ b/src/Http/Requests/StoreLargoSession.php
@@ -112,13 +112,13 @@ class StoreLargoSession extends FormRequest
      */
     protected function imageAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $chunkedI = array_chunk($annotations,config('biigle.db_param_limit')-1); 
-        foreach($chunkedI as $ci){
-            $queryReturnI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                ->whereIn('image_annotations.id', $ci)
+        $chunkedAnnotations = array_chunk($annotations,config('biigle.db_param_limit') - count($volumes)); 
+        foreach($chunkedAnnotations as $chunkedAnnotation){
+            $queryReturn = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $chunkedAnnotation)
                 ->whereNotIn('images.volume_id', $volumes)
                 ->exists();
-            if ($queryReturnI){
+            if ($queryReturn){
                 return false;
             }
         }
@@ -136,13 +136,13 @@ class StoreLargoSession extends FormRequest
      */
     protected function videoAnotationsBelongToVolumes($annotations, $volumes)
     {
-        $chunkedV = array_chunk($annotations,config('biigle.db_param_limit')-1); // config('biigle.db_param_limit')
-        foreach($chunkedV as $cv){
-            $queryReturnV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-                ->whereIn('video_annotations.id', $cv)
+        $chunkedAnnotations = array_chunk($annotations,config('biigle.db_param_limit') - count($volumes));
+        foreach($chunkedAnnotations as $chunkedAnnotation){
+            $queryReturn = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $chunkedAnnotation)
                 ->whereNotIn('videos.volume_id', $volumes)
                 ->exists();
-            if ($queryReturnV){
+            if ($queryReturn){
                 return false;
             }
         }

--- a/src/Http/Requests/StoreLargoSession.php
+++ b/src/Http/Requests/StoreLargoSession.php
@@ -112,10 +112,23 @@ class StoreLargoSession extends FormRequest
      */
     protected function imageAnotationsBelongToVolumes($annotations, $volumes)
     {
-        return !ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-            ->whereIn('image_annotations.id', $annotations)
-            ->whereNotIn('images.volume_id', $volumes)
-            ->exists();
+        $leni = count($annotations);
+        if ($leni<65000){
+            return !ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $annotations)
+                ->whereNotIn('images.volume_id', $volumes)
+                ->exists();
+        }
+        else {
+            $chunkedI = array_chunk($annotations,65000);
+            foreach($chunkedI as $ci){
+                return !ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                    ->whereIn('image_annotations.id', $ci)
+                    ->whereNotIn('images.volume_id', $volumes)
+                    ->exists();
+            }
+        }
+
     }
 
     /**
@@ -128,10 +141,22 @@ class StoreLargoSession extends FormRequest
      */
     protected function videoAnotationsBelongToVolumes($annotations, $volumes)
     {
-        return !VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-            ->whereIn('video_annotations.id', $annotations)
-            ->whereNotIn('videos.volume_id', $volumes)
-            ->exists();
+        $lenv = count($annotations);
+        if ($lenv<65000){
+            return !VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $annotations)
+                ->whereNotIn('videos.volume_id', $volumes)
+                ->exists();
+        }
+        else {
+            $chunkedV = array_chunk($annotations,65000);
+            foreach($chunkedV as $cv){
+                return !VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $cv)
+                ->whereNotIn('videos.volume_id', $volumes)
+                ->exists();
+            }
+        }
     }
 
     /**

--- a/src/Http/Requests/StoreProjectLargoSession.php
+++ b/src/Http/Requests/StoreProjectLargoSession.php
@@ -120,7 +120,7 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedImageVolumes($annotations)
     {
-        $chunkedI = array_chunk($annotations,65000);
+        $chunkedI = array_chunk($annotations,config('biigle.db_param_limit')-1);
         $volumeIdsI = [];
         foreach($chunkedI as $ci){
             $chunkVolIdI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
@@ -143,7 +143,7 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedVideoVolumes($annotations)
     {
-        $chunkedV = array_chunk($annotations,65000);
+        $chunkedV = array_chunk($annotations,config('biigle.db_param_limit')-1);
         $volumeIdsV = [];
         foreach($chunkedV as $cv){
             $chunkVolIdV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')

--- a/src/Http/Requests/StoreProjectLargoSession.php
+++ b/src/Http/Requests/StoreProjectLargoSession.php
@@ -120,10 +120,22 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedImageVolumes($annotations)
     {
-        return ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-            ->whereIn('image_annotations.id', $annotations)
-            ->distinct()
-            ->pluck('images.volume_id');
+        $leni = count($annotations);
+        if ($leni<65000){
+            return ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $annotations)
+                ->distinct()
+                ->pluck('images.volume_id');
+        }
+        else {
+            $chunkedI = array_chunk($annotations,65000);
+            foreach($chunkedI as $ci){
+                return ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                    ->whereIn('image_annotations.id', $ci)
+                    ->distinct()
+                    ->pluck('images.volume_id');
+            }
+        }
     }
 
     /**
@@ -136,9 +148,21 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedVideoVolumes($annotations)
     {
-        return VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-            ->whereIn('video_annotations.id', $annotations)
-            ->distinct()
-            ->pluck('videos.volume_id');
+        $lenv = count($annotations);
+        if ($lenv<65000){
+            return VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $annotations)
+                ->distinct()
+                ->pluck('videos.volume_id');
+        }
+        else {
+            $chunkedV = array_chunk($annotations,65000);
+            foreach($chunkedV as $cv){
+                return VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                    ->whereIn('video_annotations.id', $cv)
+                    ->distinct()
+                    ->pluck('videos.volume_id');
+            }
+        }
     }
 }

--- a/src/Http/Requests/StoreProjectLargoSession.php
+++ b/src/Http/Requests/StoreProjectLargoSession.php
@@ -120,17 +120,17 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedImageVolumes($annotations)
     {
-        $chunkedI = array_chunk($annotations,config('biigle.db_param_limit')-1);
-        $volumeIdsI = [];
-        foreach($chunkedI as $ci){
-            $chunkVolIdI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                ->whereIn('image_annotations.id', $ci)
+        $chunkedAnnotations = array_chunk($annotations,config('biigle.db_param_limit'));
+        $volumeIdsArray = [];
+        foreach($chunkedAnnotations as $chunkedAnnotation){
+            $chunkVolumeId = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $chunkedAnnotation)
                 ->distinct()
                 ->pluck('images.volume_id')
                 ->toArray();
-            $volumeIdsI = array_merge($volumeIdsI, $chunkVolIdI);
+            $volumeIdsArray = array_merge($volumeIdsArray, $chunkVolumeId);
         }
-        return array_unique($volumeIdsI);
+        return array_unique($volumeIdsArray);
     }
 
     /**
@@ -143,16 +143,16 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedVideoVolumes($annotations)
     {
-        $chunkedV = array_chunk($annotations,config('biigle.db_param_limit')-1);
-        $volumeIdsV = [];
-        foreach($chunkedV as $cv){
-            $chunkVolIdV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-                ->whereIn('video_annotations.id', $cv)
+        $chunkedAnnotations = array_chunk($annotations,config('biigle.db_param_limit'));
+        $volumeIdsArray = [];
+        foreach($chunkedAnnotations as $chunkedAnnotation){
+            $chunkVolumeId = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $chunkedAnnotation)
                 ->distinct()
                 ->pluck('videos.volume_id')
                 ->toArray();
-            $volumeIdsV = array_merge($volumeIdsV, $chunkVolIdV);
+            $volumeIdsArray = array_merge($volumeIdsArray, $chunkVolumeId);
         }
-        return array_unique($volumeIdsV);
+        return array_unique($volumeIdsArray);
     }
 }

--- a/src/Http/Requests/StoreProjectLargoSession.php
+++ b/src/Http/Requests/StoreProjectLargoSession.php
@@ -120,22 +120,17 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedImageVolumes($annotations)
     {
-        $leni = count($annotations);
-        if ($leni<65000){
-            return ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                ->whereIn('image_annotations.id', $annotations)
+        $chunkedI = array_chunk($annotations,65000);
+        $volumeIdsI = [];
+        foreach($chunkedI as $ci){
+            $chunkVolIdI = ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
+                ->whereIn('image_annotations.id', $ci)
                 ->distinct()
-                ->pluck('images.volume_id');
+                ->pluck('images.volume_id')
+                ->toArray();
+            $volumeIdsI = array_merge($volumeIdsI, $chunkVolIdI);
         }
-        else {
-            $chunkedI = array_chunk($annotations,65000);
-            foreach($chunkedI as $ci){
-                return ImageAnnotation::join('images', 'image_annotations.image_id', '=', 'images.id')
-                    ->whereIn('image_annotations.id', $ci)
-                    ->distinct()
-                    ->pluck('images.volume_id');
-            }
-        }
+        return array_unique($volumeIdsI);
     }
 
     /**
@@ -148,21 +143,16 @@ class StoreProjectLargoSession extends StoreLargoSession
      */
     protected function getAffectedVideoVolumes($annotations)
     {
-        $lenv = count($annotations);
-        if ($lenv<65000){
-            return VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-                ->whereIn('video_annotations.id', $annotations)
+        $chunkedV = array_chunk($annotations,65000);
+        $volumeIdsV = [];
+        foreach($chunkedV as $cv){
+            $chunkVolIdV = VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
+                ->whereIn('video_annotations.id', $cv)
                 ->distinct()
-                ->pluck('videos.volume_id');
+                ->pluck('videos.volume_id')
+                ->toArray();
+            $volumeIdsV = array_merge($volumeIdsV, $chunkVolIdV);
         }
-        else {
-            $chunkedV = array_chunk($annotations,65000);
-            foreach($chunkedV as $cv){
-                return VideoAnnotation::join('videos', 'video_annotations.video_id', '=', 'videos.id')
-                    ->whereIn('video_annotations.id', $cv)
-                    ->distinct()
-                    ->pluck('videos.volume_id');
-            }
-        }
+        return array_unique($volumeIdsV);
     }
 }

--- a/tests/Http/Controllers/Api/Projects/LargoControllerTest.php
+++ b/tests/Http/Controllers/Api/Projects/LargoControllerTest.php
@@ -451,19 +451,18 @@ class LargoControllerTest extends ApiTestCase
     {
         config(['biigle.db_param_limit' => 2]);
         $image = ImageTest::create(['volume_id' => $this->imageVolume->id,
-                                    'filename'=>"testImage"]);
+                                    'filename' => "testImage"]);
 
-        $imageAnnotations = ImageAnnotation::factory()->count(5)->create(['image_id' => $image->id]); // 70000
+        $imageAnnotations = ImageAnnotation::factory()->count(5)->create(['image_id' => $image->id]);
         $label = Label::factory()->create(); 
 
 
-        $imageAnnotations->each(function($imageAnnotation) use($label){
+        $imageAnnotations->each(fn($imageAnnotation) =>
             ImageAnnotationLabelTest::create([
                 'annotation_id' => $imageAnnotation->id,
                 'user_id' => $this->editor()->id,
                 'label_id' => $label->id,
-            ]);
-        });
+            ]));
 
 
         $this->beEditor();
@@ -481,18 +480,17 @@ class LargoControllerTest extends ApiTestCase
     {
         config(['biigle.db_param_limit' => 2]);
         $video = VideoTest::create(['volume_id' => $this->videoVolume->id,
-                                    'filename'=>"testVideo"]);
+                                    'filename' => "testVideo"]);
         $videoAnnotations = VideoAnnotation::factory()->count(5)->create(['video_id' => $video->id]);
 
         $label = Label::factory()->create(); 
 
-        $videoAnnotations->each(function($videoAnnotation) use($label){
+        $videoAnnotations->each(fn($videoAnnotation) =>
             VideoAnnotationLabelTest::create([
                 'annotation_id' => $videoAnnotation->id,
                 'user_id' => $this->editor()->id,
                 'label_id' => $label->id,
-            ]);
-        });
+            ]));
 
 
         $this->beEditor();

--- a/tests/Http/Controllers/Api/Projects/LargoControllerTest.php
+++ b/tests/Http/Controllers/Api/Projects/LargoControllerTest.php
@@ -4,6 +4,9 @@ namespace Biigle\Tests\Modules\Largo\Http\Controllers\Api\Projects;
 
 use ApiTestCase;
 use Biigle\MediaType;
+use Biigle\ImageAnnotation;
+use Biigle\VideoAnnotation;
+use Biigle\Label;
 use Biigle\Modules\Largo\Jobs\ApplyLargoSession;
 use Biigle\Modules\Largo\Jobs\RemoveImageAnnotationPatches;
 use Biigle\Modules\Largo\Jobs\RemoveVideoAnnotationPatches;
@@ -443,4 +446,64 @@ class LargoControllerTest extends ApiTestCase
                 'changed_video_annotations' => [],
             ])->assertStatus(422);
     }
+
+    public function testChunkingImgProject()
+    {
+        config(['biigle.db_param_limit' => 2]);
+        $image = ImageTest::create(['volume_id' => $this->imageVolume->id,
+                                    'filename'=>"testImage"]);
+
+        $imageAnnotations = ImageAnnotation::factory()->count(5)->create(['image_id' => $image->id]); // 70000
+        $label = Label::factory()->create(); 
+
+
+        $imageAnnotations->each(function($imageAnnotation) use($label){
+            ImageAnnotationLabelTest::create([
+                'annotation_id' => $imageAnnotation->id,
+                'user_id' => $this->editor()->id,
+                'label_id' => $label->id,
+            ]);
+        });
+
+
+        $this->beEditor();
+        $this->postJson("/api/v1/projects/{$this->project()->id}/largo", [
+                'dismissed_image_annotations' => [
+                    $this->imageAnnotationLabel->label_id => $imageAnnotations->pluck('id'), 
+                ],
+                'changed_image_annotations' => [],
+            ])
+            ->assertStatus(200);
+        Queue::assertPushed(ApplyLargoSession::class);
+    }
+
+    public function testChunkingVidProject()
+    {
+        config(['biigle.db_param_limit' => 2]);
+        $video = VideoTest::create(['volume_id' => $this->videoVolume->id,
+                                    'filename'=>"testVideo"]);
+        $videoAnnotations = VideoAnnotation::factory()->count(5)->create(['video_id' => $video->id]);
+
+        $label = Label::factory()->create(); 
+
+        $videoAnnotations->each(function($videoAnnotation) use($label){
+            VideoAnnotationLabelTest::create([
+                'annotation_id' => $videoAnnotation->id,
+                'user_id' => $this->editor()->id,
+                'label_id' => $label->id,
+            ]);
+        });
+
+
+        $this->beEditor();
+        $this->postJson("/api/v1/projects/{$this->project()->id}/largo", [
+                'dismissed_video_annotations' => [
+                    $this->videoAnnotationLabel->label_id => $videoAnnotations->pluck('id'), 
+                ],
+                'changed_video_annotations' => [],
+            ])
+            ->assertStatus(200);
+        Queue::assertPushed(ApplyLargoSession::class);
+    }
+
 }

--- a/tests/Http/Controllers/Api/Volumes/LargoControllerTest.php
+++ b/tests/Http/Controllers/Api/Volumes/LargoControllerTest.php
@@ -4,6 +4,9 @@ namespace Biigle\Tests\Modules\Largo\Http\Controllers\Api\Volumes;
 
 use ApiTestCase;
 use Biigle\MediaType;
+use Biigle\ImageAnnotation;
+use Biigle\VideoAnnotation;
+use Biigle\Label;
 use Biigle\Modules\Largo\Jobs\ApplyLargoSession;
 use Biigle\Modules\Largo\Jobs\RemoveImageAnnotationPatches;
 use Biigle\Modules\Largo\Jobs\RemoveVideoAnnotationPatches;
@@ -438,5 +441,65 @@ class LargoControllerTest extends ApiTestCase
                 ],
                 'changed_video_annotations' => [],
             ])->assertStatus(422);
+    }
+
+
+    public function testChunkingImgVol()
+    {
+        config(['biigle.db_param_limit' => 2]);
+        $image = ImageTest::create(['volume_id' => $this->imageVolume->id,
+                                    'filename'=>"testImage"]);
+
+        $imageAnnotations = ImageAnnotation::factory()->count(5)->create(['image_id' => $image->id]);
+        $label = Label::factory()->create(); 
+
+
+        $imageAnnotations->each(function($imageAnnotation) use($label){
+            ImageAnnotationLabelTest::create([
+                'annotation_id' => $imageAnnotation->id,
+                'user_id' => $this->editor()->id,
+                'label_id' => $label->id,
+            ]);
+        });
+
+
+        $this->beEditor();
+        $this->postJson("/api/v1/volumes/{$this->imageVolume->id}/largo", [
+                'dismissed_image_annotations' => [
+                    $this->imageAnnotationLabel->label_id => $imageAnnotations->pluck('id'), 
+                ],
+                'changed_image_annotations' => [],
+            ])
+            ->assertStatus(200);
+        Queue::assertPushed(ApplyLargoSession::class);
+    }
+
+    public function testChunkingVidVol()
+    {
+        config(['biigle.db_param_limit' => 2]);
+        $video = VideoTest::create(['volume_id' => $this->videoVolume->id,
+                                    'filename'=>"testVideo"]);
+        $videoAnnotations = VideoAnnotation::factory()->count(5)->create(['video_id' => $video->id]);
+
+        $label = Label::factory()->create(); 
+
+        $videoAnnotations->each(function($videoAnnotation) use($label){
+            VideoAnnotationLabelTest::create([
+                'annotation_id' => $videoAnnotation->id,
+                'user_id' => $this->editor()->id,
+                'label_id' => $label->id,
+            ]);
+        });
+
+
+        $this->beEditor();
+        $this->postJson("/api/v1/volumes/{$this->videoVolume->id}/largo", [
+                'dismissed_video_annotations' => [
+                    $this->videoAnnotationLabel->label_id => $videoAnnotations->pluck('id'), 
+                ],
+                'changed_video_annotations' => [],
+            ])
+            ->assertStatus(200);
+        Queue::assertPushed(ApplyLargoSession::class);
     }
 }

--- a/tests/Http/Controllers/Api/Volumes/LargoControllerTest.php
+++ b/tests/Http/Controllers/Api/Volumes/LargoControllerTest.php
@@ -448,19 +448,18 @@ class LargoControllerTest extends ApiTestCase
     {
         config(['biigle.db_param_limit' => 2]);
         $image = ImageTest::create(['volume_id' => $this->imageVolume->id,
-                                    'filename'=>"testImage"]);
+                                    'filename' => "testImage"]);
 
         $imageAnnotations = ImageAnnotation::factory()->count(5)->create(['image_id' => $image->id]);
         $label = Label::factory()->create(); 
 
 
-        $imageAnnotations->each(function($imageAnnotation) use($label){
+        $imageAnnotations->each(fn($imageAnnotation) =>
             ImageAnnotationLabelTest::create([
                 'annotation_id' => $imageAnnotation->id,
                 'user_id' => $this->editor()->id,
                 'label_id' => $label->id,
-            ]);
-        });
+            ]));
 
 
         $this->beEditor();
@@ -478,7 +477,7 @@ class LargoControllerTest extends ApiTestCase
     {
         config(['biigle.db_param_limit' => 2]);
         $video = VideoTest::create(['volume_id' => $this->videoVolume->id,
-                                    'filename'=>"testVideo"]);
+                                    'filename' => "testVideo"]);
         $videoAnnotations = VideoAnnotation::factory()->count(5)->create(['video_id' => $video->id]);
 
         $label = Label::factory()->create(); 


### PR DESCRIPTION
Chunk image and video annotations if the number of annotations gets too large (65000)

- Updated methods to handle large sets of annotations by splitting them into chunks of 65,000.
- Done for project and volume controller.

Resolves #111 