### PR TITLE
Make ApplyLargoSession job more robust against errors

### DIFF
--- a/tests/Jobs/ApplyLargoSessionTest.php
+++ b/tests/Jobs/ApplyLargoSessionTest.php
@@ -17,6 +17,7 @@ use Biigle\Tests\UserTest;
 use Biigle\Tests\VideoAnnotationLabelTest;
 use Biigle\Tests\VideoAnnotationTest;
 use Biigle\Tests\VideoTest;
+use Biigle\VolumeFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use TestCase;
@@ -27,6 +28,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $image = ImageTest::create();
+        $this->setJobId($image, 'job_id');
         $a1 = ImageAnnotationTest::create(['image_id' => $image->id]);
 
         $l1 = LabelTest::create();
@@ -57,6 +59,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $video = VideoTest::create();
+        $this->setJobId($video, 'job_id');
         $a1 = VideoAnnotationTest::create(['video_id' => $video->id]);
 
         $l1 = LabelTest::create();
@@ -87,6 +90,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $image = ImageTest::create();
+        $this->setJobId($image, 'job_id');
         $a1 = ImageAnnotationTest::create(['image_id' => $image->id]);
         $l1 = LabelTest::create();
         $al1 = ImageAnnotationLabelTest::create([
@@ -112,6 +116,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $video = VideoTest::create();
+        $this->setJobId($video, 'job_id');
         $a1 = VideoAnnotationTest::create(['video_id' => $video->id]);
         $l1 = LabelTest::create();
         $al1 = VideoAnnotationLabelTest::create([
@@ -137,6 +142,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $image = ImageTest::create();
+        $this->setJobId($image, 'job_id');
         $a1 = ImageAnnotationTest::create(['image_id' => $image->id]);
         $a2 = ImageAnnotationTest::create(['image_id' => $image->id]);
 
@@ -169,6 +175,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $video = VideoTest::create();
+        $this->setJobId($video, 'job_id');
         $a1 = VideoAnnotationTest::create(['video_id' => $video->id]);
         $a2 = VideoAnnotationTest::create(['video_id' => $video->id]);
 
@@ -201,6 +208,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $image = ImageTest::create();
+        $this->setJobId($image, 'job_id');
         $a1 = ImageAnnotationTest::create(['image_id' => $image->id]);
         $a2 = ImageAnnotationTest::create(['image_id' => $image->id]);
 
@@ -235,6 +243,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $video = VideoTest::create();
+        $this->setJobId($video, 'job_id');
         $a1 = VideoAnnotationTest::create(['video_id' => $video->id]);
         $a2 = VideoAnnotationTest::create(['video_id' => $video->id]);
 
@@ -269,6 +278,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
         $job = new ApplyLargoSession('job_id', $user, $dismissed, [], [], [], false);
@@ -284,6 +294,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
         $job = new ApplyLargoSession('job_id', $user, [], [], $dismissed, [], false);
@@ -299,6 +310,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $user2 = UserTest::create();
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
@@ -314,6 +326,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $user2 = UserTest::create();
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
@@ -329,6 +342,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -347,6 +361,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -365,6 +380,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -386,6 +402,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -407,6 +424,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -426,6 +444,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $annotation = $al1->annotation;
         $l1 = LabelTest::create();
 
@@ -445,6 +464,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $annotation = $al1->annotation;
         $al2 = ImageAnnotationLabelTest::create([
             'user_id' => $user->id,
@@ -478,6 +498,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $annotation = $al1->annotation;
         $al2 = VideoAnnotationLabelTest::create([
             'user_id' => $user->id,
@@ -555,12 +576,8 @@ class ApplyLargoSessionTest extends TestCase
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
         $changed = [$l1->id => [$al1->annotation_id]];
-        $job = new ApplyLargoSessionStub('job_id', $user, $dismissed, $changed, [], [], false);
-        try {
-            $job->handle();
-        } catch (\Exception $e) {
-            // ignore
-        }
+        $job = new ApplyLargoSession('job_id', $user, $dismissed, $changed, [], [], false);
+        $job->failed(null);
 
         $this->assertEmpty($volume->fresh()->attrs);
     }
@@ -577,12 +594,8 @@ class ApplyLargoSessionTest extends TestCase
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
         $changed = [$l1->id => [$al1->annotation_id]];
-        $job = new ApplyLargoSessionStub('job_id', $user, [], [], $dismissed, $changed, false);
-        try {
-            $job->handle();
-        } catch (\Exception $e) {
-            // ignore
-        }
+        $job = new ApplyLargoSession('job_id', $user, [], [], $dismissed, $changed, false);
+        $job->failed(null);
 
         $this->assertEmpty($volume->fresh()->attrs);
     }
@@ -592,6 +605,7 @@ class ApplyLargoSessionTest extends TestCase
         Event::fake();
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $l1 = LabelTest::create();
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
@@ -611,16 +625,13 @@ class ApplyLargoSessionTest extends TestCase
         Event::fake();
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $l1 = LabelTest::create();
 
         $dismissed = [$al1->label_id => [$al1->annotation_id]];
         $changed = [$l1->id => [$al1->annotation_id]];
-        $job = new ApplyLargoSessionStub('job_id', $user, $dismissed, $changed, [], [], false);
-        try {
-            $job->handle();
-        } catch (\Exception $e) {
-            // ignore
-        }
+        $job = new ApplyLargoSession('job_id', $user, $dismissed, $changed, [], [], false);
+        $job->failed(null);
 
         Event::assertDispatched(function (LargoSessionFailed $event) use ($user) {
             $this->assertSame($user->id, $event->user->id);
@@ -633,6 +644,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = ImageAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->image, 'job_id');
         $vector1 = ImageAnnotationLabelFeatureVector::factory()->create([
             'id' => $al1->id,
             'annotation_id' => $al1->annotation_id,
@@ -655,6 +667,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $al1 = VideoAnnotationLabelTest::create(['user_id' => $user->id]);
+        $this->setJobId($al1->annotation->video, 'job_id');
         $vector1 = VideoAnnotationLabelFeatureVector::factory()->create([
             'id' => $al1->id,
             'annotation_id' => $al1->annotation_id,
@@ -677,6 +690,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $image = ImageTest::create();
+        $this->setJobId($image, 'job_id');
         $a1 = ImageAnnotationTest::create(['image_id' => $image->id]);
         $al1 = ImageAnnotationLabelTest::create([
             'annotation_id' => $a1->id,
@@ -703,6 +717,7 @@ class ApplyLargoSessionTest extends TestCase
     {
         $user = UserTest::create();
         $video = VideoTest::create();
+        $this->setJobId($video, 'job_id');
         $a1 = VideoAnnotationTest::create(['video_id' => $video->id]);
         $al1 = VideoAnnotationLabelTest::create([
             'annotation_id' => $a1->id,
@@ -724,12 +739,12 @@ class ApplyLargoSessionTest extends TestCase
         $this->assertNotNull($a1->fresh());
         $this->assertNotNull($a2->fresh());
     }
-}
 
-class ApplyLargoSessionStub extends ApplyLargoSession
-{
-    protected function ignoreDeletedLabels($dismissed, $changed)
+    protected function setJobId(VolumeFile $file, string $id): void
     {
-        throw new \Exception;
+        $attrs = $file->volume->attrs ?? [];
+        $attrs['largo_job_id'] = $id;
+        $file->volume->attrs = $attrs;
+        $file->volume->save();
     }
 }


### PR DESCRIPTION
If a job failed for some other reason than an exception during saving, the largo_job_id was not cleaned up and no error was shown. This is handled more robustly now. Also we need a mechanism to prevent re-running of the failed job. Otherwise unexpected changes could be applied. The exprected behavior is now that the user is shown the error message and they try to save the session again. The old job should be discarded then.